### PR TITLE
fix: use signed values

### DIFF
--- a/src/useScrollPercentage.ts
+++ b/src/useScrollPercentage.ts
@@ -30,8 +30,8 @@ const useScrollPercentage = <T extends HTMLElement>(options?: UseScrollPercentag
       if (mounted && container) {
         const { scrollTop, scrollHeight, clientHeight, scrollLeft, scrollWidth, clientWidth } = container;
 
-        const verticalProgress = Math.abs((scrollTop / (scrollHeight - clientHeight)) * 100);
-        const horizontalProgress = Math.abs((scrollLeft / (scrollWidth - clientWidth)) * 100);
+        const verticalProgress = (scrollTop / (scrollHeight - clientHeight)) * 100;
+        const horizontalProgress = (scrollLeft / (scrollWidth - clientWidth)) * 100;
 
         const percentage = {
           vertical: isNaN(verticalProgress) ? 0 : verticalProgress,


### PR DESCRIPTION
Safari lets you overshoot when scrolling a page or a container. When scrolling past the start, a positive value is returned instead of the expected negative progress value.

This is due to the use of abs() when calculating the scrolling progress. Removing it fixes this inconsistency.

Before:
![before](http://static.patrickconti.fr/r/github/react-scroll-percentage-hook_signed/unsigned.gif)
After:
![before](http://static.patrickconti.fr/r/github/react-scroll-percentage-hook_signed/signed.gif)